### PR TITLE
fix: 엔티티 제약조건 변경과 DTO Validation 수정 (#29)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/user/application/UserService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/user/application/UserService.java
@@ -134,8 +134,7 @@ public class UserService {
 					request.activeEndAt(),
 					request.focusStartAt(),
 					request.focusEndAt(),
-					repeatDays,
-					request.dndFinishedAt()
+					repeatDays
 				),
 				() -> userAlarmSettingsRepository.save(new UserAlarmSettings(
 					user,
@@ -144,8 +143,7 @@ public class UserService {
 					request.activeEndAt(),
 					request.focusStartAt(),
 					request.focusEndAt(),
-					repeatDays,
-					request.dndFinishedAt()
+					repeatDays
 				))
 			);
 	}

--- a/src/main/java/com/raisedeveloper/server/domain/user/domain/UserAlarmSettings.java
+++ b/src/main/java/com/raisedeveloper/server/domain/user/domain/UserAlarmSettings.java
@@ -41,10 +41,8 @@ public class UserAlarmSettings extends CreatedUpdatedEntity {
 	@Column(nullable = false)
 	private LocalTime activeEndAt;
 
-	@Column(nullable = false)
 	private LocalTime focusStartAt;
 
-	@Column(nullable = false)
 	private LocalTime focusEndAt;
 
 	@Column(nullable = false)
@@ -62,8 +60,7 @@ public class UserAlarmSettings extends CreatedUpdatedEntity {
 		LocalTime activeEndAt,
 		LocalTime focusStartAt,
 		LocalTime focusEndAt,
-		String repeatDays,
-		LocalDateTime dndFinishedAt
+		String repeatDays
 	) {
 		this.user = user;
 		this.alarmInterval = interval;
@@ -72,7 +69,6 @@ public class UserAlarmSettings extends CreatedUpdatedEntity {
 		this.focusStartAt = focusStartAt;
 		this.focusEndAt = focusEndAt;
 		this.repeatDays = repeatDays;
-		this.dndFinishedAt = dndFinishedAt;
 		this.dnd = false;
 	}
 
@@ -82,8 +78,7 @@ public class UserAlarmSettings extends CreatedUpdatedEntity {
 		LocalTime activeEndAt,
 		LocalTime focusStartAt,
 		LocalTime focusEndAt,
-		String repeatDays,
-		LocalDateTime dndFinishedAt
+		String repeatDays
 	) {
 		this.alarmInterval = interval;
 		this.activeStartAt = activeStartAt;
@@ -91,7 +86,6 @@ public class UserAlarmSettings extends CreatedUpdatedEntity {
 		this.focusStartAt = focusStartAt;
 		this.focusEndAt = focusEndAt;
 		this.repeatDays = repeatDays;
-		this.dndFinishedAt = dndFinishedAt;
 	}
 
 	public void enableDnd(LocalDateTime dndFinishedAt) {

--- a/src/main/java/com/raisedeveloper/server/domain/user/dto/AlarmSettingsRequest.java
+++ b/src/main/java/com/raisedeveloper/server/domain/user/dto/AlarmSettingsRequest.java
@@ -2,7 +2,6 @@ package com.raisedeveloper.server.domain.user.dto;
 
 import static com.raisedeveloper.server.global.validation.RegexPatterns.*;
 
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -24,16 +23,11 @@ public record AlarmSettingsRequest(
 	@NotNull
 	LocalTime activeEndAt,
 
-	@NotNull
 	LocalTime focusStartAt,
 
-	@NotNull
 	LocalTime focusEndAt,
 
 	@NotEmpty
-	List<@Pattern(regexp = REPEAT_DAY_REGEX) String> repeatDays,
-
-	@NotNull
-	LocalDateTime dndFinishedAt
+	List<@Pattern(regexp = REPEAT_DAY_REGEX) String> repeatDays
 ) {
 }


### PR DESCRIPTION
# 🔷 Github Issue ID
- #29 

# 📌 작업 내용 및 특이사항
- 엔티티 제약조건 변경 내용 반영
  - alarm_settings 테이블 `focus_start_at`, `focus_end_at` 모두 nullable 처리
- API 수정
  - 제약 조건 반영 DTO validation 수정

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
