### PR TITLE
fix: Push 에 담을 본문 데이터 생성 중 포맷 일치하지 않아 발생하는 에러 해결 (#47)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/push/application/FcmService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/push/application/FcmService.java
@@ -1,6 +1,6 @@
 package com.raisedeveloper.server.domain.push.application;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
@@ -81,7 +81,7 @@ public class FcmService implements PushService {
 	}
 
 	private Map<String, String> buildSessionData(ExerciseSession session) {
-		String timestamp = LocalDate.now()
+		String timestamp = LocalDateTime.now()
 			.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
 		return Map.of(


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #47

# 📌 작업 내용 및 특이사항

개발 서버에서 스케줄러 실행 중 다음과 같은 오류가 발생함을 확인

```
Jan 28 00:37:00 raisedeveloper-dev java[18458]: java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: HourOfDay
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.LocalDate.get0(LocalDate.java:700) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.LocalDate.getLong(LocalDate.java:680) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimePrintContext.getValue(DateTimePrintContext.java:308) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimeFormatterBuilder$NumberPrinterParser.format(DateTimeFormatterBuilder.java:2914) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format(DateTimeFormatterBuilder.java:2538) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format(DateTimeFormatterBuilder.java:2538) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimeFormatter.formatTo(DateTimeFormatter.java:1905) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.format.DateTimeFormatter.format(DateTimeFormatter.java:1879) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/java.time.LocalDate.format(LocalDate.java:1799) ~[na:na]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at com.raisedeveloper.server.domain.push.application.FcmService.buildSessionData(FcmService.java:85) ~[!/:0.0.1-SNAPSHOT]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at com.raisedeveloper.server.domain.push.application.FcmService.sendSessionPush(FcmService.java:51) ~[!/:0.0.1-SNAPSHOT]
Jan 28 00:37:00 raisedeveloper-dev java[18458]:         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[na:na]
```

스케줄러가 실행되며 Push 를 전송하기 위해서 body 에 담을 데이터를 생성해야 하며, 본문에 포함되는 데이터로 TimeStamp 를 찍게 되는데 
FCM 서비스의 본문 데이터는 String 이어야 하기에 이를 변환하는 과정에서 포맷이 일치하지 않아 에러 발생

```
	private Map<String, String> buildSessionData(ExerciseSession session) {
		**String timestamp = LocalDate.now()
			.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);**

		return Map.of(
			"type", "SESSION_READY",
			"id", String.valueOf(session.getId()),
			"ts", timestamp,
			"sessionId", String.valueOf(session.getId()),
			"routineId", String.valueOf(session.getRoutine().getId())
		);
	}
```

**해결**
LocalDateTime 으로 포맷을 일치

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
