### PR TITLE
feat(metrics): enable HTTP P95/P99 latency histograms for Prometheus

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,6 +26,10 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
 
+# Micrometer HTTP latency: enable histogram buckets + percentiles (P95/P99)
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.distribution.percentiles.http.server.requests=0.95,0.99
+
 # Jwt settings
 security.jwt.issuer=raise-developer
 security.jwt.secret-base64=${JWT_SECRET}


### PR DESCRIPTION
# 🔷 Github Issue ID
- 

# 📌 작업 내용 및 특이사항
- P95/P99 메트릭 수집을 위한 properties 수정

# 📚 참고사항
- 
