### PR TITLE
fix: 스케줄러에서 `@Transactional` 제거 (#51)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.raisedeveloper.server.domain.exercise.application.ExerciseService;
 import com.raisedeveloper.server.domain.exercise.domain.ExerciseSession;
@@ -35,7 +34,6 @@ public class PushAlarmScheduler {
 	private final ExerciseService exerciseService;
 
 	@Scheduled(cron = "0 */1 * * * *")
-	@Transactional
 	public void processAlarms() {
 		log.info("푸시 알람 스케줄러 시작");
 		long startTime = System.currentTimeMillis();


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #51 

https://github.com/orgs/100-hours-a-week/projects/288?pane=issue&itemId=152294287&issue=100-hours-a-week%7C1-team-one-wiki%7C262

# 📌 작업 내용 및 특이사항
- 스케줄러의 경우 별도 DB 에 접근하고 있는 로직이 아니므로 @Transactional 제거
- 이를 통해서 #51 에서 프록시를 넘어서 예외가 전파되어 스케줄러 트랜잭션이 전체 롤백되는 문제 해결

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
