### PR TITLE
refactor: RoutineService N + 1 문제 해결 (#108)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/routine/application/RoutineService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/routine/application/RoutineService.java
@@ -54,7 +54,7 @@ public class RoutineService {
 
 		List<Long> routineIds = routines.stream().map(Routine::getId).toList();
 		List<RoutineStep> steps = routineStepRepository
-			.findAllByRoutineIdIn(routineIds);
+			.findAllByRoutineIdInOrderByIdAsc(routineIds);
 
 		steps.sort(Comparator.comparingInt(s -> s.getRoutine().getRoutineOrder()));
 

--- a/src/main/java/com/raisedeveloper/server/domain/routine/infra/RoutineStepRepository.java
+++ b/src/main/java/com/raisedeveloper/server/domain/routine/infra/RoutineStepRepository.java
@@ -2,6 +2,7 @@ package com.raisedeveloper.server.domain.routine.infra;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +12,9 @@ import com.raisedeveloper.server.domain.routine.domain.RoutineStep;
 
 @Repository
 public interface RoutineStepRepository extends JpaRepository<RoutineStep, Long> {
-	List<RoutineStep> findAllByRoutineIdIn(
+
+	@EntityGraph(attributePaths = {"routine", "exercise"})
+	List<RoutineStep> findAllByRoutineIdInOrderByIdAsc(
 		List<Long> routineIds
 	);
 


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #108 

# 📌 작업 내용 및 특이사항
- RoutineStepRepository 에서 EntityGraph 를 활용하여 N + 1 문제 해결
- 성능 측정 및 기록 진행
- **쿼리 수 70% 감소** ( 13 -> 3 ), 서비스 **응답 시간 50 % 감소**

# 📚 참고사항
- [N+1 문제와 EntityGraph 를 활용한 해결](https://ahead-citrine-f63.notion.site/N-1-300577ab4aae8065bbe4fd13a3af62b5?source=copy_link)
