### PR TITLE
fix: set minhealth to 100% for zero downtime deployment

### DIFF
--- a/.github/workflows/deploy-asg-rolling.yml
+++ b/.github/workflows/deploy-asg-rolling.yml
@@ -218,7 +218,7 @@ jobs:
           # - Production (2대): 50% (1대는 죽이고 1대는 살림 -> 롤링)
           # - Staging (1대): 0% (새거 띄우고 옛날거 죽이거나, 잠시 다운타임 허용)
           if [ "${{ inputs.environment }}" == "production" ]; then
-            MIN_HEALTHY=50
+            MIN_HEALTHY=100
           else
             MIN_HEALTHY=0 # 1대일 경우 100%를 유지하려면 Max Capacity가 2여야 함
           fi


### PR DESCRIPTION
# 🔷 Github Issue ID
- 작업한 내용에 해당하는 Issue 링크

# 📌 작업 내용 및 특이사항
- 안전한 무중단 배포를 위해 살아 있는 최소 인스턴스 비율을 100%로 설정

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
