### PR TITLE
fix: 눈 운동 limit_time 이 AI 응답 그대로 저장될 수 있도록 수정 (#195)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/routine/application/RoutineService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/routine/application/RoutineService.java
@@ -156,7 +156,7 @@ public class RoutineService {
 					exercise,
 					stepDto.targetReps() != null ? stepDto.targetReps().shortValue() : null,
 					stepDto.durationTime() != null ? stepDto.durationTime().shortValue() : null,
-					EYES.equals(stepDto.type()) ? 0 : stepDto.limitTime().shortValue(),
+					stepDto.limitTime().shortValue(),
 					stepDto.stepOrder().shortValue()
 				);
 				routineStepRepository.save(step);


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #195 

# 📌 작업 내용 및 특이사항
- 눈 운동 limit 을 무조건 0 으로 저장하고 있던 오류 수정

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
