### PR TITLE
fix: 게시글 태그 수정 기능 동작 로직 수정 (#207)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/post/application/PostService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/post/application/PostService.java
@@ -303,18 +303,41 @@ public class PostService {
 		replacePostImages(post, imagePaths);
 	}
 
-	private void replacePostTags(Post post, List<String> tagNamesRaw) {
-		List<String> tagNames = normalizeDistinctList(tagNamesRaw);
-		postTagRepository.deleteAllByPostId(post.getId());
-		if (tagNames.isEmpty()) {
+	private void updatePostTagsIfChanged(Post post, List<String> tagNamesRaw) {
+		List<String> desiredTagNames = normalizeDistinctList(tagNamesRaw);
+		List<Tag> existingTags = postTagRepository.findTagsByPostId(post.getId());
+
+		Map<String, Tag> existingTagByName = existingTags.stream()
+			.collect(Collectors.toMap(Tag::getName, tag -> tag));
+		Set<String> existingTagNames = existingTagByName.keySet();
+		Set<String> desiredTagNameSet = Set.copyOf(desiredTagNames);
+
+		if (existingTagNames.equals(desiredTagNameSet)) {
 			return;
 		}
 
-		List<Tag> existingTags = tagRepository.findByNameIn(tagNames);
-		Map<String, Tag> tagByName = existingTags.stream()
+		List<Long> tagIdsToRemove = existingTagNames.stream()
+			.filter(name -> !desiredTagNameSet.contains(name))
+			.map(existingTagByName::get)
+			.filter(Objects::nonNull)
+			.map(Tag::getId)
+			.toList();
+		if (!tagIdsToRemove.isEmpty()) {
+			postTagRepository.deleteByPostIdAndTagIdIn(post.getId(), tagIdsToRemove);
+		}
+
+		List<String> tagNamesToAdd = desiredTagNames.stream()
+			.filter(name -> !existingTagNames.contains(name))
+			.toList();
+		if (tagNamesToAdd.isEmpty()) {
+			return;
+		}
+
+		List<Tag> persistedTags = tagRepository.findByNameIn(tagNamesToAdd);
+		Map<String, Tag> tagByName = persistedTags.stream()
 			.collect(Collectors.toMap(Tag::getName, tag -> tag));
 
-		List<Tag> missingTags = tagNames.stream()
+		List<Tag> missingTags = tagNamesToAdd.stream()
 			.filter(name -> !tagByName.containsKey(name))
 			.map(Tag::new)
 			.toList();
@@ -323,23 +346,14 @@ public class PostService {
 			savedTags.forEach(tag -> tagByName.put(tag.getName(), tag));
 		}
 
-		List<PostTag> postTags = tagNames.stream()
+		List<PostTag> postTagsToAdd = tagNamesToAdd.stream()
 			.map(tagByName::get)
 			.filter(Objects::nonNull)
 			.map(tag -> new PostTag(post, tag))
 			.toList();
-		if (!postTags.isEmpty()) {
-			postTagRepository.saveAll(postTags);
+		if (!postTagsToAdd.isEmpty()) {
+			postTagRepository.saveAll(postTagsToAdd);
 		}
-	}
-
-	private void updatePostTagsIfChanged(Post post, List<String> tagNamesRaw) {
-		List<String> tagNames = normalizeDistinctList(tagNamesRaw);
-		Set<String> existingTagNames = Set.copyOf(postTagRepository.findTagNamesByPostId(post.getId()));
-		if (existingTagNames.equals(Set.copyOf(tagNames))) {
-			return;
-		}
-		replacePostTags(post, tagNames);
 	}
 
 	private List<String> normalizeDistinctList(List<String> values) {

--- a/src/main/java/com/raisedeveloper/server/domain/post/infra/PostTagRepository.java
+++ b/src/main/java/com/raisedeveloper/server/domain/post/infra/PostTagRepository.java
@@ -3,6 +3,7 @@ package com.raisedeveloper.server.domain.post.infra;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,13 +12,19 @@ import com.raisedeveloper.server.domain.post.domain.Tag;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
-	void deleteAllByPostId(Long postId);
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("DELETE FROM PostTag pt WHERE pt.post.id = :postId")
+	void deleteAllByPostId(@Param("postId") Long postId);
 
 	@Query("SELECT pt.tag.name FROM PostTag pt WHERE pt.post.id = :postId")
 	List<String> findTagNamesByPostId(@Param("postId") Long postId);
 
 	@Query("SELECT pt.tag FROM PostTag pt WHERE pt.post.id = :postId")
 	List<Tag> findTagsByPostId(@Param("postId") Long postId);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("DELETE FROM PostTag pt WHERE pt.post.id = :postId AND pt.tag.id IN :tagIds")
+	void deleteByPostIdAndTagIdIn(@Param("postId") Long postId, @Param("tagIds") List<Long> tagIds);
 
 	@Query("""
 		SELECT pt FROM PostTag pt


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes 207

# 📌 작업 내용 및 특이사항
- 기존 모든 태그 삭제 및 삽입하여 처리하고 있었고, 이로 인하여 JPA flush 과정에서 삭제와 관련해 duplicate key 오류 발생
- 수정이 필요한 태그에 대해서만 삭제 / 삽입하도록 수정하여 근본적인 원인 해결

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
