### PR TITLE
fix: ExerciseSessionFailScheduler 동작 수정 (#226)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/exercise/infra/ExerciseSessionRepository.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/infra/ExerciseSessionRepository.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -66,9 +67,13 @@ public interface ExerciseSessionRepository extends JpaRepository<ExerciseSession
 
 	@Query("SELECT es FROM ExerciseSession es "
 		+ "WHERE es.isRoutineCompleted IS NULL "
-		+ "AND es.updatedAt = es.createdAt "
-		+ "AND es.createdAt <= :cutoff")
-	List<ExerciseSession> findStaleUnupdatedSessions(@Param("cutoff") LocalDateTime cutoff);
+		+ "AND es.startAt IS NULL "
+		+ "AND es.createdAt <= :cutoff "
+		+ "ORDER BY es.createdAt ASC, es.id ASC")
+	List<ExerciseSession> findStaleUnupdatedSessions(
+		@Param("cutoff") LocalDateTime cutoff,
+		Pageable pageable
+	);
 
 	@Query("SELECT es.user.id as userId, MAX(es.createdAt) as lastCreatedAt "
 		+ "FROM ExerciseSession es "
@@ -78,14 +83,14 @@ public interface ExerciseSessionRepository extends JpaRepository<ExerciseSession
 
 	@Query(value = """
 		SELECT
-		    es.user_id AS userId,
+			es.user_id AS userId,
 		    ROUND(
 		        SUM(CASE WHEN es.start_at IS NOT NULL THEN 1 ELSE 0 END) / COUNT(es.id),
 		        2
 		    ) AS weeklyFrequency
 		FROM exercise_sessions es
 		WHERE es.created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
-		  AND es.user_id IN (:userIds)
+		  	AND es.user_id IN (:userIds)
 		GROUP BY es.user_id
 		""", nativeQuery = true)
 	List<WeeklyFrequencyProjection> findWeeklyFrequenciesByUserIds(@Param("userIds") List<Long> userIds);

--- a/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/ExerciseSessionFailScheduler.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/ExerciseSessionFailScheduler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,22 +29,30 @@ import lombok.extern.slf4j.Slf4j;
 public class ExerciseSessionFailScheduler {
 
 	private static final long STALE_MINUTES = 15;
+	private static final int BATCH_SIZE = 1_000;
 
 	private final ExerciseSessionRepository exerciseSessionRepository;
 	private final ExerciseResultRepository exerciseResultRepository;
 	private final UserCharacterRepository userCharacterRepository;
 	private final NotificationService notificationService;
 
-	@Scheduled(cron = "0 */5 * * * *", scheduler = "defaultTaskScheduler")
+	@Scheduled(cron = "0 */1 * * * *", scheduler = "defaultTaskScheduler")
 	@SchedulerLock(name = "ExerciseSessionFailScheduler.failStaleSessions", lockAtMostFor = "PT10M")
 	@Transactional
 	public void failStaleSessions() {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime cutoff = now.minusMinutes(STALE_MINUTES);
+		int processedCount = processBatch(cutoff, now);
+		log.info("세션 자동 실패 처리 완료: {} 건", processedCount);
+	}
 
-		List<ExerciseSession> staleSessions = exerciseSessionRepository.findStaleUnupdatedSessions(cutoff);
+	private int processBatch(LocalDateTime cutoff, LocalDateTime failedAt) {
+		List<ExerciseSession> staleSessions = exerciseSessionRepository.findStaleUnupdatedSessions(
+			cutoff,
+			PageRequest.of(0, BATCH_SIZE)
+		);
 		if (staleSessions.isEmpty()) {
-			return;
+			return 0;
 		}
 
 		List<Long> sessionIds = staleSessions.stream()
@@ -57,10 +66,10 @@ public class ExerciseSessionFailScheduler {
 				Collectors.counting()
 			));
 
-		results.forEach(result -> result.stepResultsFailed(now));
+		results.forEach(result -> result.stepResultsFailed(failedAt));
 
 		for (ExerciseSession session : staleSessions) {
-			session.sessionFailed(now);
+			session.sessionFailed(failedAt);
 			int failedCount = Math.toIntExact(
 				failedResultCounts.getOrDefault(session.getId(), 0L)
 			);
@@ -80,6 +89,6 @@ public class ExerciseSessionFailScheduler {
 			character.subtractStatusScore(failedCount);
 			notificationService.createStretchingFailed(session.getUser());
 		}
-		log.info("세션 자동 실패 처리 완료: {} 건", staleSessions.size());
+		return staleSessions.size();
 	}
 }


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #226 

# 📌 작업 내용 및 특이사항
- cron interval 을 1분으로 감소시키고, 1000개씩만 데이터를 불러와서 처리하도록 수정
- scheduler 가 종료될 때 항상 처리한 Session 개수를 로그로 출력

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
