### PR TITLE
fix: 다음 알림 전송 시각 계산 로직 수정 (#249)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleService.java
@@ -287,8 +287,8 @@ public class AlarmScheduleService {
 			local leaseUntil = ARGV[3]
 			local candidates = redis.call('ZRANGEBYSCORE', dueKey, '-inf', nowScore, 'LIMIT', 0, limit)
 			for i, member in ipairs(candidates) do
-			  redis.call('ZREM', dueKey, member)
-			  redis.call('ZADD', processingKey, leaseUntil, member)
+				redis.call('ZREM', dueKey, member)
+			 	redis.call('ZADD', processingKey, leaseUntil, member)
 			end
 			return candidates
 			""");

--- a/src/main/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleService.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleService.java
@@ -152,13 +152,15 @@ public class AlarmScheduleService {
 			return null;
 		}
 
-		LocalDateTime nextFireAt = baseTime.truncatedTo(ChronoUnit.MINUTES)
+		// 1. 기준 일시 = 현재 + interval
+		LocalDateTime threshold = baseTime.truncatedTo(ChronoUnit.MINUTES)
 			.plusMinutes(settings.getAlarmInterval());
 
+		// 2. DND 확인, 설정되어 있는 경우 다음 기준 일시 = dnd 종료 시각 + interval
 		if (settings.isDnd()) {
 			LocalDateTime dndFinishedAt = settings.getDndFinishedAt();
-			if (dndFinishedAt != null && nextFireAt.isBefore(dndFinishedAt)) {
-				nextFireAt = dndFinishedAt.plusMinutes(settings.getAlarmInterval());
+			if (dndFinishedAt != null && threshold.isBefore(dndFinishedAt)) {
+				threshold = dndFinishedAt.plusMinutes(settings.getAlarmInterval());
 			}
 		}
 
@@ -167,48 +169,33 @@ public class AlarmScheduleService {
 			return null;
 		}
 
-		if (!repeatDays.contains(nextFireAt.getDayOfWeek())) {
-			LocalDate nextRepeat = nextRepeatDay(nextFireAt.toLocalDate(), repeatDays);
-			if (nextRepeat == null) {
-				return null;
-			}
-			nextFireAt = LocalDateTime.of(nextRepeat, activeStart)
-				.plusMinutes(settings.getAlarmInterval());
-		}
-
-		LocalTime candidate = nextFireAt.toLocalTime();
 		LocalTime focusStart = settings.getFocusStartAt();
 		LocalTime focusEnd = settings.getFocusEndAt();
 
-		boolean inActive = !candidate.isBefore(activeStart) && !candidate.isAfter(activeEnd);
-		boolean inFocus = focusStart != null && focusEnd != null
-			&& !candidate.isBefore(focusStart) && !candidate.isAfter(focusEnd);
-
-		if (inActive && !inFocus) {
-			return nextFireAt;
-		}
-
-		if (!inActive) {
-			if (candidate.isAfter(activeEnd)) {
-				return moveToNextRepeatDay(nextFireAt.toLocalDate(), repeatDays, activeStart);
+		// 3. 반복 요일 내에서 후보 날짜 탐색
+		// 해당 일자부터 시작하여 alarm_settings 설정 바탕으로 유효 슬롯 검색
+		// 1주일 뒤로 밀리는 경우에는 스케줄링 하지 않고 null 반환
+		for (int i = 0; i <= MAX_LOOKAHEAD_DAYS; i++) {
+			LocalDate candidateDate = threshold.toLocalDate().plusDays(i);
+			if (!repeatDays.contains(candidateDate.getDayOfWeek())) {
+				continue;
 			}
 
-			LocalDateTime shifted = LocalDateTime.of(nextFireAt.toLocalDate(), activeStart)
-				.plusMinutes(settings.getAlarmInterval());
-
-			if (shifted.toLocalTime().isAfter(activeEnd)) {
-				return moveToNextRepeatDay(nextFireAt.toLocalDate(), repeatDays, activeStart);
+			LocalDateTime candidate = resolveCandidateForDate(
+				candidateDate,
+				threshold,
+				activeStart,
+				activeEnd,
+				focusStart,
+				focusEnd,
+				settings.getAlarmInterval()
+			);
+			if (candidate != null) {
+				return candidate;
 			}
-			return shifted;
 		}
 
-
-		LocalTime afterFocus = focusEnd.plusMinutes(settings.getAlarmInterval());
-		if (!afterFocus.isBefore(activeStart) && !afterFocus.isAfter(activeEnd)) {
-			return LocalDateTime.of(nextFireAt.toLocalDate(), afterFocus);
-		}
-
-		return moveToNextRepeatDay(nextFireAt.toLocalDate(), repeatDays, activeStart);
+		return null;
 	}
 
 	private Set<DayOfWeek> parseRepeatDays(String repeatDays) {
@@ -236,12 +223,49 @@ public class AlarmScheduleService {
 		return null;
 	}
 
-	private LocalDateTime moveToNextRepeatDay(LocalDate baseDate, Set<DayOfWeek> repeatDays, LocalTime activeStart) {
-		LocalDate nextRepeat = nextRepeatDay(baseDate, repeatDays);
-		if (nextRepeat == null) {
+	private LocalDateTime resolveCandidateForDate(
+		LocalDate candidateDate,
+		LocalDateTime threshold,
+		LocalTime activeStart,
+		LocalTime activeEnd,
+		LocalTime focusStart,
+		LocalTime focusEnd,
+		int intervalMinutes
+	) {
+		LocalDateTime windowStart = LocalDateTime.of(candidateDate, activeStart)
+			.plusMinutes(intervalMinutes);
+		LocalDateTime windowEnd = LocalDateTime.of(candidateDate, activeEnd);
+
+		LocalDateTime candidate = candidateDate.equals(threshold.toLocalDate())
+			? threshold
+			: windowStart;
+		if (candidate.isBefore(windowStart)) {
+			candidate = windowStart;
+		}
+		if (candidate.isAfter(windowEnd)) {
 			return null;
 		}
-		return LocalDateTime.of(nextRepeat, activeStart);
+
+		if (focusStart == null || focusEnd == null) {
+			return candidate;
+		}
+
+		LocalDateTime focusStartAt = LocalDateTime.of(candidateDate, focusStart);
+		LocalDateTime focusEndAt = LocalDateTime.of(candidateDate, focusEnd);
+		boolean inFocus = !candidate.isBefore(focusStartAt) && !candidate.isAfter(focusEndAt);
+		if (!inFocus) {
+			return candidate;
+		}
+
+		LocalDateTime afterFocus = focusEndAt.plusMinutes(intervalMinutes);
+		if (afterFocus.isBefore(windowStart)) {
+			afterFocus = windowStart;
+		}
+		if (afterFocus.isAfter(windowEnd)) {
+			return null;
+		}
+
+		return afterFocus;
 	}
 
 	private double toScore(LocalDateTime time) {

--- a/src/test/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleServiceTest.java
+++ b/src/test/java/com/raisedeveloper/server/domain/exercise/application/AlarmScheduleServiceTest.java
@@ -2,8 +2,10 @@ package com.raisedeveloper.server.domain.exercise.application;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,23 +17,45 @@ class AlarmScheduleServiceTest {
 	private final AlarmScheduleService alarmScheduleService = new AlarmScheduleService(null, null);
 
 	@Test
-	void calculateNextFireAt_movesToNextRepeatDay_whenFocusWindowConsumesRemainingActiveTime() {
-		User user = new User("user46@example.com", "password");
+	void calculateNextFireAtReturnsNullWhenFocusCoversEntireActiveWindow() {
 		UserAlarmSettings settings = new UserAlarmSettings(
-			user,
-			(short)60,
+			new User("focus-wrap@test.com", "pw"),
+			(short)10,
+			LocalTime.of(0, 0),
+			LocalTime.of(23, 50),
+			LocalTime.of(0, 0),
+			LocalTime.of(23, 50),
+			allDays()
+		);
+		LocalDateTime baseTime = LocalDateTime.of(2026, 3, 18, 11, 0);
+
+		LocalDateTime nextFireAt = alarmScheduleService.calculateNextFireAt(settings, baseTime);
+
+		assertThat(nextFireAt).isNull();
+	}
+
+	@Test
+	void calculateNextFireAtMovesToNextDayForFocusEndingAtActiveEnd() {
+		UserAlarmSettings settings = new UserAlarmSettings(
+			new User("focus-end@test.com", "pw"),
+			(short)10,
 			LocalTime.of(10, 0),
 			LocalTime.of(16, 0),
 			LocalTime.of(12, 0),
 			LocalTime.of(16, 0),
-			"MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY,SATURDAY,SUNDAY"
+			allDays()
 		);
+		LocalDateTime baseTime = LocalDateTime.of(2026, 3, 18, 12, 0);
 
-		LocalDateTime nextFireAt = alarmScheduleService.calculateNextFireAt(
-			settings,
-			LocalDateTime.of(2026, 3, 16, 11, 0)
-		);
+		LocalDateTime nextFireAt = alarmScheduleService.calculateNextFireAt(settings, baseTime);
 
-		assertThat(nextFireAt).isEqualTo(LocalDateTime.of(2026, 3, 17, 10, 0));
+		assertThat(nextFireAt).isEqualTo(LocalDateTime.of(2026, 3, 19, 10, 10));
+		assertThat(nextFireAt).isAfter(baseTime);
+	}
+
+	private String allDays() {
+		return String.join(",", Arrays.stream(DayOfWeek.values())
+			.map(Enum::name)
+			.toList());
 	}
 }


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #249

# 📌 작업 내용 및 특이사항
- date 가 바뀌면서 다시 과거로 돌아가는 문제 해결
- focus 시간이 active 시간을 덮어버려서 다음 유효 슬롯이 없는 경우 스케줄에서 제거

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
