### PR TITLE
feat: outbox 스케줄러 병목 해결 (#251)

### DIFF
--- a/src/main/java/com/raisedeveloper/server/domain/exercise/event/AlarmEventPublisher.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/event/AlarmEventPublisher.java
@@ -1,8 +1,11 @@
 package com.raisedeveloper.server.domain.exercise.event;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.raisedeveloper.server.global.outbox.application.OutboxEventStore;
+import com.raisedeveloper.server.global.outbox.application.OutboxEventStore.OutboxStoreCommand;
 import com.raisedeveloper.server.global.outbox.domain.OutboxAggregateType;
 import com.raisedeveloper.server.global.outbox.domain.OutboxEventType;
 
@@ -60,5 +63,23 @@ public class AlarmEventPublisher {
 			event.userId().toString(),
 			event
 		);
+	}
+
+	public void publishDueUsers(List<AlarmDueUserEvent> events) {
+		if (events == null || events.isEmpty()) {
+			return;
+		}
+
+		outboxEventStore.storeBatch(events.stream()
+			.map(event -> new OutboxStoreCommand(
+				event.eventId(),
+				OutboxAggregateType.ALARM,
+				event.userId().toString(),
+				ExerciseKafkaTopics.ALARM_DUE_USER_V1,
+				OutboxEventType.ALARM_DUE_USER,
+				event.userId().toString(),
+				event
+			))
+			.toList());
 	}
 }

--- a/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
@@ -82,7 +82,8 @@ public class PushAlarmScheduler {
 				break;
 			}
 
-			Map<Long, UserAlarmSettings> settingsByUserId = userAlarmSettingsRepository.findByUserIdInWithUser(claimedUserIds)
+			Map<Long, UserAlarmSettings> settingsByUserId = userAlarmSettingsRepository.findByUserIdInWithUser(
+					claimedUserIds)
 				.stream()
 				.collect(Collectors.toMap(s -> s.getUser().getId(), Function.identity()));
 

--- a/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
+++ b/src/main/java/com/raisedeveloper/server/domain/exercise/scheduler/PushAlarmScheduler.java
@@ -3,6 +3,7 @@ package com.raisedeveloper.server.domain.exercise.scheduler;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -85,7 +86,7 @@ public class PushAlarmScheduler {
 				.stream()
 				.collect(Collectors.toMap(s -> s.getUser().getId(), Function.identity()));
 
-			int publishedInLoop = 0;
+			List<AlarmDueUserEvent> dueUserEvents = new ArrayList<>(claimedUserIds.size());
 			for (Long userId : claimedUserIds) {
 				UserAlarmSettings settings = settingsByUserId.get(userId);
 				if (settings == null || settings.getNextFireAt() == null) {
@@ -93,15 +94,16 @@ public class PushAlarmScheduler {
 					continue;
 				}
 
-				alarmEventPublisher.publishDueUser(new AlarmDueUserEvent(
+				dueUserEvents.add(new AlarmDueUserEvent(
 					UUID.randomUUID().toString(),
 					userId,
 					settings.getNextFireAt(),
 					LocalDateTime.now(),
 					UUID.randomUUID().toString()
 				));
-				publishedInLoop++;
 			}
+			alarmEventPublisher.publishDueUsers(dueUserEvents);
+			int publishedInLoop = dueUserEvents.size();
 
 			loopCount++;
 			totalClaimed += claimedUserIds.size();

--- a/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
@@ -1,5 +1,8 @@
 package com.raisedeveloper.server.global.outbox.application;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,5 +61,43 @@ public class OutboxEventStore {
 			);
 			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	@Transactional
+	public void storeBatch(List<OutboxStoreCommand> commands) {
+		if (commands == null || commands.isEmpty()) {
+			return;
+		}
+
+		List<OutboxEvent> outboxEvents = new ArrayList<>(commands.size());
+		try {
+			for (OutboxStoreCommand command : commands) {
+				String payloadJson = objectMapper.writeValueAsString(command.payload());
+				outboxEvents.add(new OutboxEvent(
+					command.eventId(),
+					command.aggregateType().getValue(),
+					command.aggregateId(),
+					command.topic(),
+					command.eventType().getValue(),
+					command.messageKey(),
+					payloadJson
+				));
+			}
+			outboxEventRepository.saveAll(outboxEvents);
+		} catch (JsonProcessingException e) {
+			log.error("Outbox batch payload serialization failed: size={}", commands.size(), e);
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public record OutboxStoreCommand(
+		String eventId,
+		OutboxAggregateType aggregateType,
+		String aggregateId,
+		String topic,
+		OutboxEventType eventType,
+		String messageKey,
+		Object payload
+	) {
 	}
 }

--- a/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
@@ -94,15 +94,15 @@ public class OutboxEventStore {
 				""",
 				new BatchPreparedStatementSetter() {
 					@Override
-					public void setValues(PreparedStatement ps, int i) throws SQLException {
-						OutboxStoreCommand command = commands.get(i);
+					public void setValues(PreparedStatement ps, int num) throws SQLException {
+						OutboxStoreCommand command = commands.get(num);
 						ps.setString(1, command.eventId());
 						ps.setString(2, command.aggregateType().getValue());
 						ps.setString(3, command.aggregateId());
 						ps.setString(4, command.topic());
 						ps.setString(5, command.eventType().getValue());
 						ps.setString(6, command.messageKey());
-						ps.setString(7, payloads.get(i));
+						ps.setString(7, payloads.get(num));
 						ps.setString(8, OutboxStatus.PENDING.name());
 						ps.setTimestamp(9, null);
 						ps.setInt(10, 0);

--- a/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxEventStore.java
@@ -1,8 +1,12 @@
 package com.raisedeveloper.server.global.outbox.application;
 
-import java.util.ArrayList;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.List;
 
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +17,7 @@ import com.raisedeveloper.server.global.exception.ErrorCode;
 import com.raisedeveloper.server.global.outbox.domain.OutboxAggregateType;
 import com.raisedeveloper.server.global.outbox.domain.OutboxEvent;
 import com.raisedeveloper.server.global.outbox.domain.OutboxEventType;
+import com.raisedeveloper.server.global.outbox.domain.OutboxStatus;
 import com.raisedeveloper.server.global.outbox.infra.OutboxEventRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +30,7 @@ public class OutboxEventStore {
 
 	private final OutboxEventRepository outboxEventRepository;
 	private final ObjectMapper objectMapper;
+	private final JdbcTemplate jdbcTemplate;
 
 	@Transactional
 	public void store(
@@ -69,24 +75,57 @@ public class OutboxEventStore {
 			return;
 		}
 
-		List<OutboxEvent> outboxEvents = new ArrayList<>(commands.size());
 		try {
-			for (OutboxStoreCommand command : commands) {
-				String payloadJson = objectMapper.writeValueAsString(command.payload());
-				outboxEvents.add(new OutboxEvent(
-					command.eventId(),
-					command.aggregateType().getValue(),
-					command.aggregateId(),
-					command.topic(),
-					command.eventType().getValue(),
-					command.messageKey(),
-					payloadJson
-				));
-			}
-			outboxEventRepository.saveAll(outboxEvents);
-		} catch (JsonProcessingException e) {
-			log.error("Outbox batch payload serialization failed: size={}", commands.size(), e);
+			List<String> payloads = commands.stream()
+				.map(command -> {
+					try {
+						return objectMapper.writeValueAsString(command.payload());
+					} catch (JsonProcessingException e) {
+						throw new PayloadSerializationException(e);
+					}
+				})
+				.toList();
+
+			Timestamp now = Timestamp.valueOf(java.time.LocalDateTime.now());
+			jdbcTemplate.batchUpdate("""
+				INSERT INTO outbox_events
+				(event_id, aggregate_type, aggregate_id, topic, event_type, message_key, payload, status, published_at, retry_count, last_error, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+				new BatchPreparedStatementSetter() {
+					@Override
+					public void setValues(PreparedStatement ps, int i) throws SQLException {
+						OutboxStoreCommand command = commands.get(i);
+						ps.setString(1, command.eventId());
+						ps.setString(2, command.aggregateType().getValue());
+						ps.setString(3, command.aggregateId());
+						ps.setString(4, command.topic());
+						ps.setString(5, command.eventType().getValue());
+						ps.setString(6, command.messageKey());
+						ps.setString(7, payloads.get(i));
+						ps.setString(8, OutboxStatus.PENDING.name());
+						ps.setTimestamp(9, null);
+						ps.setInt(10, 0);
+						ps.setString(11, null);
+						ps.setTimestamp(12, now);
+						ps.setTimestamp(13, now);
+					}
+
+					@Override
+					public int getBatchSize() {
+						return commands.size();
+					}
+				}
+			);
+		} catch (PayloadSerializationException e) {
+			log.error("Outbox batch payload serialization failed: size={}", commands.size(), e.getCause());
 			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private static final class PayloadSerializationException extends RuntimeException {
+		private PayloadSerializationException(JsonProcessingException cause) {
+			super(cause);
 		}
 	}
 

--- a/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxStateService.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/application/OutboxStateService.java
@@ -3,9 +3,12 @@ package com.raisedeveloper.server.global.outbox.application;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.raisedeveloper.server.global.outbox.domain.OutboxEvent;
 import com.raisedeveloper.server.global.outbox.domain.OutboxStatus;
 import com.raisedeveloper.server.global.outbox.infra.OutboxEventRepository;
 
@@ -18,7 +21,12 @@ public class OutboxStateService {
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public List<Long> claimPendingBatchIds(int batchSize) {
-		List<Long> ids = outboxEventRepository.findPendingIdsForUpdateSkipLocked(batchSize);
+		List<Long> ids = outboxEventRepository.findByStatusOrderByIdAsc(
+			OutboxStatus.PENDING,
+			PageRequest.of(0, batchSize)
+		).stream()
+			.map(OutboxEvent::getId)
+			.toList();
 		if (ids.isEmpty()) {
 			return List.of();
 		}

--- a/src/main/java/com/raisedeveloper/server/global/outbox/infra/OutboxEventRepository.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/infra/OutboxEventRepository.java
@@ -33,8 +33,8 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
 	@Query("""
 		UPDATE OutboxEvent o
 		SET o.status = com.raisedeveloper.server.global.outbox.domain.OutboxStatus.PUBLISHED,
-		    o.publishedAt = :publishedAt,
-		    o.lastError = null
+			o.publishedAt = :publishedAt,
+			o.lastError = null
 		WHERE o.id IN :outboxIds
 		""")
 	int markPublishedBatch(
@@ -46,8 +46,8 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
 	@Query("""
 		UPDATE OutboxEvent o
 		SET o.status = com.raisedeveloper.server.global.outbox.domain.OutboxStatus.PENDING,
-		    o.retryCount = o.retryCount + 1,
-		    o.lastError = :errorMessage
+			o.retryCount = o.retryCount + 1,
+			o.lastError = :errorMessage
 		WHERE o.id IN :outboxIds
 		""")
 	int markRetryBatch(

--- a/src/main/java/com/raisedeveloper/server/global/outbox/infra/OutboxEventRepository.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/infra/OutboxEventRepository.java
@@ -16,16 +16,6 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
 
 	List<OutboxEvent> findByStatusOrderByIdAsc(OutboxStatus status, Pageable pageable);
 
-	@Query(value = """
-		SELECT id
-		FROM outbox_events
-		WHERE status = 'PENDING'
-		ORDER BY id ASC
-		LIMIT :limit
-		FOR UPDATE SKIP LOCKED
-		""", nativeQuery = true)
-	List<Long> findPendingIdsForUpdateSkipLocked(@Param("limit") int limit);
-
 	List<OutboxEvent> findByIdInOrderByIdAsc(List<Long> ids);
 
 	@Modifying

--- a/src/main/java/com/raisedeveloper/server/global/outbox/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/raisedeveloper/server/global/outbox/scheduler/OutboxRelayScheduler.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
 import com.raisedeveloper.server.global.outbox.application.OutboxRelayService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class OutboxRelayScheduler {
 		fixedDelayString = "${app.outbox.relay.fixed-delay-ms:1000}",
 		scheduler = "outboxTaskScheduler"
 	)
+	@SchedulerLock(name = "OutboxRelayScheduler.relay", lockAtMostFor = "PT30S", lockAtLeastFor = "PT1S")
 	public void relay() {
 		outboxRelayService.relayPendingBatch(batchSize);
 	}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -91,7 +91,7 @@ spring.app.kafka.alarm-push.concurrency=${APP_KAFKA_ALARM_PUSH_CONCURRENCY:6}
 
 # Outbox
 app.outbox.relay.fixed-delay-ms=${OUTBOX_RELAY_DELAY_MS:1000}
-app.outbox.relay.batch-size=${OUTBOX_RELAY_BATCH_SIZE:100}
+app.outbox.relay.batch-size=${OUTBOX_RELAY_BATCH_SIZE:400}
 app.scheduler.default.pool-size=${APP_SCHEDULER_DEFAULT_POOL_SIZE:4}
 app.scheduler.outbox.pool-size=${APP_SCHEDULER_OUTBOX_POOL_SIZE:1}
 


### PR DESCRIPTION
# 🔷 Github Issue ID
Closes #251

# 📌 작업 내용 및 특이사항
- outbox scheduler 가 하나의 인스턴스에서만 동작하도록 수정
- lock 을 잡고 outbox 이벤트를 업데이트 하는 부분 제거
- outbox scheduler batch size, delay 조정

# 📚 참고사항
- PR 리뷰 과정에서 참고하면 좋을 내용들
